### PR TITLE
Pull request: `feat/proxy-traffic-flow-live-map` → `develop`

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,7 +14,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DataGate Monitor</title>
-    <script type="module" crossorigin src="/assets/index-ypxb5BOz.js"></script>
+    <script type="module" crossorigin src="/assets/index-_DsnQpmJ.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/chunk-DseTPa7n.js">
     <link rel="modulepreload" crossorigin href="/assets/storedProfileAvatar-CZD2RHeX.js">
     <link rel="modulepreload" crossorigin href="/assets/jsx-runtime-B-G0DNmd.js">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagate-monitor-frontend-vite",
   "private": true,
-  "version": "1.3.71",
+  "version": "1.3.72",
   "type": "module",
   "engines": {
     "node": ">=24.14.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ const GeneralSettings = lazy(() => import("./pages/GeneralSettings"));
 const GeoLiteDbSettings = lazy(() => import("./pages/GeoLiteDbSettings"));
 const NotificationVpnProfileSettings = lazy(() => import("./pages/NotificationVpnProfileSettings"));
 const AndroidCrashReportsSettings = lazy(() => import("./pages/AndroidCrashReportsSettings"));
+const WindowsCrashReportsSettings = lazy(() => import("./pages/WindowsCrashReportsSettings"));
 const TelegramBotSettings = lazy(() => import("./pages/TelegramBotSettings"));
 const UsersSettings = lazy(() => import("./pages/UsersSettings/UsersSettings"));
 const UserQuotasPage = lazy(() => import("./pages/UsersSettings/UserQuotasPage"));
@@ -171,6 +172,16 @@ function App() {
                         element={
                           isAdmin(getCurrentUser()) ? (
                             withSuspense(<AndroidCrashReportsSettings />)
+                          ) : (
+                            <Navigate to="/settings/general" replace />
+                          )
+                        }
+                      />
+                      <Route
+                        path="windows-crashes"
+                        element={
+                          isAdmin(getCurrentUser()) ? (
+                            withSuspense(<WindowsCrashReportsSettings />)
                           ) : (
                             <Navigate to="/settings/general" replace />
                           )

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -14,6 +14,7 @@ import {
   FaSlidersH,
   FaTelegram,
   FaUsers,
+  FaWindows,
 } from "react-icons/fa";
 import { getCurrentUser, isAdmin } from "../utils/auth/authSelectors";
 import "../css/Settings.css";
@@ -36,6 +37,7 @@ const ALL_SETTINGS_TABS: SettingsTab[] = [
   { label: "Users", path: "users", Icon: FaUsers, mobilePrefix: "👥" },
   { label: "Email broadcast", path: "email-broadcast", Icon: FaEnvelope, mobilePrefix: "✉️" },
   { label: "Android crashes", path: "android-crashes", Icon: FaBug, mobilePrefix: "🐞" },
+  { label: "Windows crashes", path: "windows-crashes", Icon: FaWindows, mobilePrefix: "🪟" },
   { label: "Admin password", path: "admin-password", Icon: FaKey, mobilePrefix: "🔑" },
 ];
 
@@ -46,7 +48,10 @@ export function Settings() {
   const tabs = isAdmin(getCurrentUser())
     ? ALL_SETTINGS_TABS
     : ALL_SETTINGS_TABS.filter(
-        (t) => t.path !== "admin-password" && t.path !== "android-crashes",
+        (t) =>
+          t.path !== "admin-password" &&
+          t.path !== "android-crashes" &&
+          t.path !== "windows-crashes",
       );
 
   const pathRest = location.pathname.replace(/^\/settings\/?/, "") || "general";

--- a/src/pages/WindowsCrashReportsSettings.tsx
+++ b/src/pages/WindowsCrashReportsSettings.tsx
@@ -1,0 +1,329 @@
+import { useMemo, useState } from "react";
+import axios from "axios";
+import { useQuery } from "@tanstack/react-query";
+import type { GridColDef } from "@mui/x-data-grid";
+import { FaBug, FaSync, FaWindows } from "react-icons/fa";
+import StyledDataGrid from "../components/ui/TableStyle.tsx";
+import CustomThemeProvider from "../components/ui/ThemeProvider.tsx";
+import { getApiBaseUrlResolved } from "../api/apirequest";
+import { ACCESS_TOKEN_KEY } from "../utils/const";
+import { errorMessage } from "../utils/errorMessage";
+import "../css/Settings.css";
+import "../css/Table.css";
+
+type RecentWindowsCrashReportDto = {
+  id: number;
+  receivedAt: string;
+  appProcess: string;
+  fileName: string;
+  parseStatus: string;
+  timestampUtc?: string | null;
+  process?: string | null;
+  thread?: string | null;
+  sdk?: string | null;
+  device?: string | null;
+  kind?: string | null;
+  exception?: string | null;
+  message?: string | null;
+  tag?: string | null;
+  stacktrace?: string | null;
+  payloadRaw?: string | null;
+};
+
+const DEFAULT_LIMIT = 100;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 200;
+
+async function getRecentWindowsCrashes(limit: number): Promise<RecentWindowsCrashReportDto[]> {
+  const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+  if (!token) throw new Error("Access token is missing.");
+  const base = await getApiBaseUrlResolved();
+  const url = `${base}/api/v1/windows/crash-ingest/recent?limit=${encodeURIComponent(String(limit))}`;
+  const response = await axios.get<RecentWindowsCrashReportDto[]>(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return Array.isArray(response.data) ? response.data : [];
+}
+
+export default function WindowsCrashReportsSettings() {
+  const [limitInput, setLimitInput] = useState<string>(String(DEFAULT_LIMIT));
+  const [appliedLimit, setAppliedLimit] = useState<number>(DEFAULT_LIMIT);
+  const [processFilter, setProcessFilter] = useState<string>("");
+  const [selectedCrash, setSelectedCrash] = useState<RecentWindowsCrashReportDto | null>(null);
+
+  const crashesQuery = useQuery({
+    queryKey: ["windows-crash-reports", appliedLimit],
+    queryFn: () => getRecentWindowsCrashes(appliedLimit),
+    staleTime: 10_000,
+  });
+
+  const filteredRows = useMemo(() => {
+    const rows = crashesQuery.data ?? [];
+    const filter = processFilter.trim().toLowerCase();
+    if (!filter) return rows;
+    return rows.filter((r) => (r.appProcess ?? "").toLowerCase().includes(filter));
+  }, [crashesQuery.data, processFilter]);
+
+  const columns: GridColDef[] = [
+    { field: "id", headerName: "ID", width: 90 },
+    {
+      field: "receivedAt",
+      headerName: "Received",
+      width: 180,
+      valueFormatter: (value) => (value ? new Date(String(value)).toLocaleString() : "—"),
+    },
+    { field: "appProcess", headerName: "App process", flex: 0.35, minWidth: 180 },
+    { field: "fileName", headerName: "File", flex: 0.25, minWidth: 150 },
+    { field: "parseStatus", headerName: "Parse", width: 110 },
+    {
+      field: "thread",
+      headerName: "Thread",
+      width: 160,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.thread ?? "",
+    },
+    {
+      field: "device",
+      headerName: "Device",
+      flex: 0.3,
+      minWidth: 170,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.device ?? "",
+    },
+    {
+      field: "sdk",
+      headerName: "SDK",
+      width: 90,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.sdk ?? "",
+    },
+    {
+      field: "kind",
+      headerName: "Kind",
+      width: 110,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.kind ?? "",
+    },
+    {
+      field: "tag",
+      headerName: "Tag",
+      flex: 0.25,
+      minWidth: 140,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.tag ?? "",
+    },
+    { field: "exception", headerName: "Exception", flex: 0.35, minWidth: 180 },
+    {
+      field: "message",
+      headerName: "Message",
+      flex: 0.5,
+      minWidth: 220,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.message ?? "",
+    },
+    {
+      field: "stacktrace",
+      headerName: "Stacktrace",
+      flex: 0.6,
+      minWidth: 260,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.stacktrace ?? "",
+      renderCell: (params) => {
+        const value = String(params.value ?? "");
+        if (!value) return "—";
+        const preview = value.length > 140 ? `${value.slice(0, 140)}...` : value;
+        return <span title={value}>{preview}</span>;
+      },
+    },
+    {
+      field: "payloadRaw",
+      headerName: "Raw payload",
+      flex: 0.6,
+      minWidth: 260,
+      valueGetter: (_value, row: RecentWindowsCrashReportDto) => row.payloadRaw ?? "",
+      renderCell: (params) => {
+        const value = String(params.value ?? "");
+        if (!value) return "—";
+        const preview = value.length > 140 ? `${value.slice(0, 140)}...` : value;
+        return <span title={value}>{preview}</span>;
+      },
+    },
+    {
+      field: "actions",
+      headerName: "Details",
+      width: 110,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <button
+          type="button"
+          className="btn secondary"
+          onClick={() => setSelectedCrash(params.row as RecentWindowsCrashReportDto)}
+        >
+          View
+        </button>
+      ),
+    },
+  ];
+
+  const applyLimit = () => {
+    const parsed = Number(limitInput);
+    if (!Number.isFinite(parsed)) return;
+    const bounded = Math.max(MIN_LIMIT, Math.min(MAX_LIMIT, Math.trunc(parsed)));
+    setAppliedLimit(bounded);
+    setLimitInput(String(bounded));
+  };
+
+  return (
+    <div>
+      <h2 className="settings-page__h2-with-icon">
+        <FaWindows className="icon" aria-hidden />
+        <span>Windows crash reports</span>
+      </h2>
+
+      <p className="settings-item-description" style={{ marginBottom: 14, maxWidth: 980 }}>
+        Shows recent desktop crash reports from `api/v1/windows/crash-ingest/recent`. Data is redacted by backend.
+      </p>
+
+      <div className="settings-item" style={{ marginBottom: 14, flexWrap: "wrap", gap: 8 }}>
+        <label htmlFor="windows-crash-limit">Limit</label>
+        <input
+          id="windows-crash-limit"
+          type="number"
+          min={MIN_LIMIT}
+          max={MAX_LIMIT}
+          className="input"
+          style={{ width: 120 }}
+          value={limitInput}
+          onChange={(e) => setLimitInput(e.target.value)}
+        />
+        <button type="button" className="btn secondary" onClick={applyLimit}>
+          Apply
+        </button>
+
+        <label htmlFor="windows-crash-process-filter" style={{ marginLeft: 8 }}>
+          Filter by process
+        </label>
+        <input
+          id="windows-crash-process-filter"
+          type="text"
+          className="input"
+          style={{ minWidth: 260 }}
+          placeholder="com.imkolganov.datagate.win"
+          value={processFilter}
+          onChange={(e) => setProcessFilter(e.target.value)}
+        />
+
+        <button type="button" className="btn secondary" onClick={() => void crashesQuery.refetch()}>
+          <FaSync className={`icon ${crashesQuery.isFetching ? "icon-spin" : ""}`} aria-hidden /> Refresh
+        </button>
+      </div>
+
+      {crashesQuery.error && (
+        <p className="error-message" style={{ marginBottom: 14 }}>
+          Failed to load crash reports: {errorMessage(crashesQuery.error)}
+        </p>
+      )}
+
+      <CustomThemeProvider>
+        <div
+          className="data-grid-wrap"
+          style={{ backgroundColor: "var(--bg-body)", padding: 10, borderRadius: 8 }}
+        >
+          <StyledDataGrid
+            rows={filteredRows}
+            columns={columns}
+            getRowId={(r) => (r as RecentWindowsCrashReportDto).id}
+            loading={crashesQuery.isLoading || crashesQuery.isFetching}
+            disableRowSelectionOnClick
+            pageSizeOptions={[10, 20, 50, 100]}
+            slotProps={{ loadingOverlay: { variant: "skeleton", noRowsVariant: "skeleton" } }}
+            localeText={{ noRowsLabel: "No crash reports found." }}
+          />
+        </div>
+      </CustomThemeProvider>
+
+      {selectedCrash && (
+        <div className="modal-overlay" onClick={() => setSelectedCrash(null)}>
+          <div
+            className="modal-content"
+            style={{ maxWidth: 980, width: "100%" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="modal-header">
+              <h3>
+                <FaBug className="icon" aria-hidden /> Crash #{selectedCrash.id}
+              </h3>
+              <button
+                type="button"
+                className="modal-close"
+                aria-label="Close"
+                onClick={() => setSelectedCrash(null)}
+              >
+                ×
+              </button>
+            </div>
+
+            <div style={{ padding: "0 20px 16px" }}>
+              <dl className="user-detail-dl">
+                <dt>Received</dt>
+                <dd>{selectedCrash.receivedAt ? new Date(selectedCrash.receivedAt).toLocaleString() : "—"}</dd>
+                <dt>App process</dt>
+                <dd>{selectedCrash.appProcess || "—"}</dd>
+                <dt>File</dt>
+                <dd>{selectedCrash.fileName || "—"}</dd>
+                <dt>Parse status</dt>
+                <dd>{selectedCrash.parseStatus || "—"}</dd>
+                <dt>Exception</dt>
+                <dd>{selectedCrash.exception || "—"}</dd>
+                <dt>Message</dt>
+                <dd>{selectedCrash.message || "—"}</dd>
+                <dt>Thread</dt>
+                <dd>{selectedCrash.thread || "—"}</dd>
+                <dt>Device</dt>
+                <dd>{selectedCrash.device || "—"}</dd>
+                <dt>SDK</dt>
+                <dd>{selectedCrash.sdk || "—"}</dd>
+                <dt>Kind</dt>
+                <dd>{selectedCrash.kind || "—"}</dd>
+                <dt>Tag</dt>
+                <dd>{selectedCrash.tag || "—"}</dd>
+              </dl>
+
+              <h4 style={{ marginTop: 14, marginBottom: 8 }}>Stacktrace</h4>
+              <pre
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  maxHeight: 300,
+                  overflow: "auto",
+                  background: "var(--bg-body)",
+                  border: "1px solid var(--border-color)",
+                  borderRadius: 8,
+                  padding: 10,
+                }}
+              >
+                {selectedCrash.stacktrace || "—"}
+              </pre>
+
+              <h4 style={{ marginTop: 14, marginBottom: 8 }}>Raw payload</h4>
+              <pre
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  maxHeight: 300,
+                  overflow: "auto",
+                  background: "var(--bg-body)",
+                  border: "1px solid var(--border-color)",
+                  borderRadius: 8,
+                  padding: 10,
+                }}
+              >
+                {selectedCrash.payloadRaw || "—"}
+              </pre>
+            </div>
+
+            <div className="modal-actions" style={{ padding: "0 20px 20px" }}>
+              <button type="button" className="btn secondary" onClick={() => setSelectedCrash(null)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull request: `feat/proxy-traffic-flow-live-map` → `develop`

**Repository:** OpenVpnGateMonitorFrontend  
**Branch:** `feat/proxy-traffic-flow-live-map`  
**Base:** `develop`  
**Commits:** 34 · **~475 files** (large Orval regen + dist assets)

---

## Title

```
feat: live proxy traffic maps, admin 2FA, Telegram login, settings sidebar, v3 catalog
```

---

## Summary

Major frontend increment relative to `develop`: live OpenVPN proxy traffic visualization (per-server and global overview), operational/status-stream UX, v3 VPN server catalog, admin security (TOTP, idle session, Telegram code login, active sessions), settings layout improvements, Windows crash reports UI, and privacy-aware statistics for non-admins. API clients regenerated via **Orval** from backend OpenAPI.

### Live proxy traffic flow
- Per-server and **global servers overview** traffic maps with globe/visualization.
- Traffic routed through **backend SignalR hub** (not direct agent connection from browser).
- Gated by server version; offline playback mode on overview; diagnostics for payload parsing and IP matching.
- Multiple stabilization fixes for subscriptions, rendering, and overview API payload shapes (wrapped vs unwrapped).

### VPN servers & operations
- **v3 server catalog** UI with quota view-only notices and stack logos (OpenVPN / Xray).
- Post-create setup progress UI; preserve quota plans on server update.
- Status stream logs UI (Orval); emphasize failures in server details.
- Slow polling server indicators; server log clear action.
- Advanced cycle parallelism metrics in status logs.
- Map/table layout fixes (phantom scrollbars, overview stability).

### Admin authentication & security
- **TOTP 2FA:** login challenge step, security settings page (enroll / disable), QR setup (`qrcode`), optional password on disable for password-based admins.
- **Orval-only auth APIs:** removed hand-written `totpApi`; `orvalPayload` shim for typed `ApiResponse` unwrap.
- **Idle admin session:** session policy + activity heartbeat (`adminIdleSession.ts`).
- **Telegram code login:** form under “Continue with Telegram”; instructions for `/login_code` only; TOTP challenge after code login when required.
- **Active sessions** on security settings (list / revoke); interim `adminSessionsApi` until full Orval coverage for session endpoints.
- `RequireAdminTotpSetup` guard for admins without TOTP when policy requires it.
- Shared login flow helper: `handleLoginResponse.ts`, `tokenExpiryScheduler.ts`.

### Settings & navigation
- **Left sidebar** layout for settings (full-width content area for tables/grids).
- Routes: General, API clients, quotas, GeoLite, notifications, Telegram bot, users, email broadcast, Android/Windows crashes, admin password, **Security (2FA)**.

### Privacy & access control
- Restrict per-user statistics for non-admins.
- Gate admin UI routes; access-denied page for unauthorized resources.

### Windows crash reports
- Settings page and route for Windows crash report management.

### Tooling & build
- Orval client regeneration (large diff under `src/api/orval/`).
- `vite.config` updates; release/cache hardening; dist entrypoint refresh.
- Version bumps (e.g. 1.3.89, 1.3.90).

---

## Key paths (for reviewers)

| Area | Paths |
|------|--------|
| Traffic maps | `src/pages/ServersOverview/`, server details / proxy traffic components |
| Auth | `src/components/auth/`, `src/utils/auth/`, `src/pages/AdminSecuritySettings.tsx` |
| Settings shell | `src/pages/Settings.tsx`, `src/css/Settings.css` |
| Orval | `src/api/orval/`, `orval.config.ts`, `src/api/orvalModelShim.ts` |
| Windows crashes | settings route in `App.tsx`, dedicated settings page |

---

## Dependencies / integration

- Requires **deployed backend** with matching OpenAPI (v3 servers, auth, sessions, traffic hub, status stream).
- **SharedModels** types flow through generated Orval models + `orvalModelShim.ts` aliases.
- After backend merge: run `npm run gen:api` (or project’s Orval script) if swagger changed again.
- Telegram bot: users obtain codes via **`/login_code`** only.

---

## Commits (34, oldest → newest)

1. `1b1b87b` — feat: add Windows crash reports settings page and route  
2. `f3085f0` — feat: add live proxy traffic map and globe visualization  
3. `74cac9e` — fix: force proxy traffic flow through backend hub  
4. `16cd039` — fix: gate traffic flow stream by server version  
5. `084d8fa` — fix: improve traffic flow IP matching and bump frontend version  
6. `3ae4aed` — feat: add global live proxy traffic map for all servers  
7. `5a2afce` — fix: restore live traffic rendering on overview and server pages  
8. `87edbd3` — fix: improve live traffic map matching and refresh control  
9. `1c0d450` — fix: add detailed traffic-flow diagnostics and robust payload parsing  
10. `0de57a6` — fix: resolve single-server flow rendering and surface mapping diagnostics  
11. `e8833ff` — fix: restore global traffic subscriptions on servers overview  
12. `c6fd33c` — fix: use strict typed API response access on servers overview  
13. `7530926` — chore: refresh build artifact after overview fix  
14. `218519f` — fix: restore overview traffic subscriptions and log server list  
15. `8e3fe8c` — fix: support wrapped or unwrapped overview API payloads  
16. `49e5776` — feat: add offline playback mode for servers overview traffic map  
17. `2050074` — fix: stabilize proxy traffic map behavior on servers overview  
18. `9b6816d` — fix: stabilize servers maps and remove phantom table scrollbars  
19. `a569ef0` — fix: harden frontend release resiliency and cache policy  
20. `681195d` — feat: regenerate orval API and wire status stream logs UI  
21. `cc3f87f` — feat: emphasize status stream failures in details view  
22. `f9f98a3` — chore: refresh dist entrypoint asset references  
23. `c5105f2` — feat: surface slow polling servers and bump frontend to 1.3.89  
24. `3798e07` — feat: add server-log clear action and bump frontend to 1.3.90  
25. `be309a3` — feat: parse advanced cycle parallelism metrics in status logs  
26. `6644378` — feat: post-create setup progress UI and preserve quota plans on update  
27. `9cb18c5` — feat(ui): restrict per-user statistics access for non-admins  
28. `a59f5cc` — Gate admin UI routes and show access denied for restricted resources  
29. `e521459` — feat(web): v3 server catalog, quota view-only UX, and OpenAPI client regen  
30. `2befe25` — feat(auth): admin 2FA login challenge and security settings UI  
31. `94eb4c5` — refactor(auth): use Orval for admin TOTP and idle session APIs  
32. `72af62e` — fix(auth): TOTP QR code and optional password on 2FA disable  
33. `fa9d8f9` — feat(auth): Telegram code login, admin sessions, and settings sidebar  
34. `0cc8aeb` — fix(auth): clarify Telegram code login instructions on sign-in page  

---

## Test plan

- [ ] `npm ci` / `npm run build`  
- [ ] `npm run lint` (if used in CI)  
- [ ] Login: password, Google, Telegram code (`/login_code` from bot) + TOTP challenge when enabled  
- [ ] Security settings: TOTP enroll (QR), disable (with/without password admin), active sessions revoke  
- [ ] Idle session: stay idle past policy → forced re-auth  
- [ ] Settings: sidebar navigation on desktop; mobile dropdown; all sections load  
- [ ] Servers overview: global traffic map, offline mode, no duplicate subscriptions / memory leaks (smoke)  
- [ ] Server details: per-server traffic map, status stream logs, slow polling badge, clear logs  
- [ ] v3 catalog / quota view-only notice for restricted users  
- [ ] Non-admin: statistics masked / access denied on admin routes  
- [ ] Windows crash reports settings page (smoke)  
- [ ] `npm run gen:api` against staging swagger if backend PR merged after this branch was cut  

---

## Create PR (CLI)

```bash
cd frontend   # OpenVpnGateMonitorFrontend clone
git push -u origin feat/proxy-traffic-flow-live-map

gh pr create --base develop --head feat/proxy-traffic-flow-live-map \
  --title "feat: live proxy traffic maps, admin 2FA, Telegram login, settings sidebar, v3 catalog" \
  --body-file PR_feat-proxy-traffic-flow-live-map_to_develop.md
```

To paste into GitHub UI manually, copy from **Summary** through **Test plan** (exclude this file’s header and CLI section if you prefer a shorter description).
