### PR TITLE
Add GDPR cookie consent and privacy policy

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,24 +14,21 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DataGate Monitor</title>
-    <script type="module" crossorigin src="/assets/index-BCxhUTxa.js"></script>
+    <script type="module" crossorigin src="/assets/index-DNSG9ZHY.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-aKtaBQYM.js">
     <link rel="modulepreload" crossorigin href="/assets/react-DYWI7JNT.js">
     <link rel="modulepreload" crossorigin href="/assets/mui-CFpWGBaT.js">
     <link rel="modulepreload" crossorigin href="/assets/QueryClientProvider-B6sEmlrr.js">
     <link rel="modulepreload" crossorigin href="/assets/useMutation-CMeAd3_b.js">
+    <link rel="modulepreload" crossorigin href="/assets/cookieConsent-Bomgz9Yx.js">
     <link rel="modulepreload" crossorigin href="/assets/mutator-DsOCpavc.js">
     <link rel="modulepreload" crossorigin href="/assets/providerExternalIdFromJwt-DjMV61yh.js">
     <link rel="modulepreload" crossorigin href="/assets/authSelectors-C4PMvWR5.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-D7bEmnWf.css">
+    <link rel="modulepreload" crossorigin href="/assets/i18n-DfMi_pp-.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-Ch2LCDbJ.css">
   </head>
   <body>
     <div id="root"></div>
     <script src="/env.js"></script>
-    <script
-            src="https://accounts.google.com/gsi/client"
-            async
-            defer
-    ></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,10 +19,5 @@
     <div id="root"></div>
     <script src="/env.js"></script>
     <script type="module" src="/src/main.tsx"></script>
-    <script
-            src="https://accounts.google.com/gsi/client"
-            async
-            defer
-    ></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,9 @@ import { scheduleAutoLogout } from "./utils/auth/tokenExpiryScheduler.ts";
 import { RequireAdmin } from "./components/auth/RequireAdmin.tsx";
 import { RequireAdminTotpSetup } from "./components/auth/RequireAdminTotpSetup.tsx";
 import { withSuspense } from "./utils/withSuspense.tsx";
+import { CookieConsentProvider } from "./contexts/CookieConsentContext.tsx";
+import CookieConsentBanner from "./components/gdpr/CookieConsentBanner.tsx";
+import CookieSettingsPanel from "./components/gdpr/CookieSettingsPanel.tsx";
 
 // Lazy pages
 const About = lazy(() => import("./pages/About"));
@@ -62,6 +65,7 @@ const StatusStreamLogs = lazy(() => import("./pages/StatusStreamLogs"));
 const XrayLoginPage = lazy(() => import("./pages/xray/XrayLoginPage.tsx"));
 const XrayPortalPage = lazy(() => import("./pages/xray/XrayPortalPage.tsx"));
 const XrayRegisterPage = lazy(() => import("./pages/xray/XrayRegisterPage.tsx"));
+const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy.tsx"));
 
 const isAuthenticated = () => !!localStorage.getItem(ACCESS_TOKEN_KEY);
 
@@ -75,6 +79,7 @@ const XrayPrivateRoute = ({ children }: { children: ReactNode }): React.ReactEle
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
   const isAuthPage =
+    location.pathname === "/privacy" ||
     location.pathname === "/login" ||
     location.pathname === "/xray/login" ||
     location.pathname === "/xray/register" ||
@@ -110,8 +115,10 @@ function App() {
   return (
     <div className="app-container">
       <Router>
+        <CookieConsentProvider>
         <Layout>
           <Routes>
+            <Route path="/privacy" element={withSuspense(<PrivacyPolicy />)} />
             <Route path="/login" element={withSuspense(<LoginPage />)} />
             <Route path="/xray/login" element={withSuspense(<XrayLoginPage />)} />
             <Route path="/xray/register" element={withSuspense(<XrayRegisterPage />)} />
@@ -238,6 +245,9 @@ function App() {
             />
           </Routes>
         </Layout>
+        <CookieConsentBanner />
+        <CookieSettingsPanel />
+        </CookieConsentProvider>
       </Router>
 
       <ToastContainer

--- a/src/components/VpnMap.tsx
+++ b/src/components/VpnMap.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
-import Cookies from "js-cookie";
+import { getPreferenceCookie, setPreferenceCookie } from "../utils/gdpr/cookieConsent";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import type { VpnClientInfoDto } from "../api/orvalModelShim";
@@ -400,19 +400,19 @@ const VpnMap: React.FC<VpnMapProps> = ({
   const [globeHeight, setGlobeHeight] = useState(580);
 
   const [selectedLayer, setSelectedLayer] = useState<keyof typeof tileLayers>(
-      (Cookies.get("selectedMapLayer") as keyof typeof tileLayers) || "Carto Dark"
+      (getPreferenceCookie("selectedMapLayer") as keyof typeof tileLayers) || "Carto Dark"
   );
   const [pointColor, setPointColor] = useState<MarkerColor>(
-      (Cookies.get("selectedPointColor") as MarkerColor) || "red"
+      (getPreferenceCookie("selectedPointColor") as MarkerColor) || "red"
   );
   const [viewMode, setViewMode] = useState<MapViewMode>(
-      (Cookies.get("selectedMapViewMode") as MapViewMode) || "map"
+      (getPreferenceCookie("selectedMapViewMode") as MapViewMode) || "map"
   );
   const [performanceMode, setPerformanceMode] = useState<PerformanceMode>(
-      (Cookies.get("selectedMapPerformanceMode") as PerformanceMode) || "auto"
+      (getPreferenceCookie("selectedMapPerformanceMode") as PerformanceMode) || "auto"
   );
   const [globeTrafficLayer, setGlobeTrafficLayer] = useState<GlobeTrafficLayer>(
-      (Cookies.get("selectedGlobeTrafficLayer") as GlobeTrafficLayer) || "arcs"
+      (getPreferenceCookie("selectedGlobeTrafficLayer") as GlobeTrafficLayer) || "arcs"
   );
   const [viewportSize, setViewportSize] = useState(() => ({
     width: window.innerWidth,
@@ -431,19 +431,19 @@ const VpnMap: React.FC<VpnMapProps> = ({
   }, []);
 
   useEffect(() => {
-    Cookies.set("selectedMapLayer", selectedLayer, { expires: 365 });
+    setPreferenceCookie("selectedMapLayer", selectedLayer);
   }, [selectedLayer]);
   useEffect(() => {
-    Cookies.set("selectedPointColor", pointColor, { expires: 365 });
+    setPreferenceCookie("selectedPointColor", pointColor);
   }, [pointColor]);
   useEffect(() => {
-    Cookies.set("selectedMapViewMode", viewMode, { expires: 365 });
+    setPreferenceCookie("selectedMapViewMode", viewMode);
   }, [viewMode]);
   useEffect(() => {
-    Cookies.set("selectedMapPerformanceMode", performanceMode, { expires: 365 });
+    setPreferenceCookie("selectedMapPerformanceMode", performanceMode);
   }, [performanceMode]);
   useEffect(() => {
-    Cookies.set("selectedGlobeTrafficLayer", globeTrafficLayer, { expires: 365 });
+    setPreferenceCookie("selectedGlobeTrafficLayer", globeTrafficLayer);
   }, [globeTrafficLayer]);
 
   useEffect(() => {

--- a/src/components/auth/GoogleLoginForm.tsx
+++ b/src/components/auth/GoogleLoginForm.tsx
@@ -10,6 +10,8 @@ import {
   applyLoginFlow,
   type TotpChallengeState,
 } from "../../utils/auth/handleLoginResponse";
+import { acceptsThirdParty } from "../../utils/gdpr/cookieConsent";
+import { useCookieConsent } from "../../contexts/CookieConsentContext";
 
 type GoogleCredentialResponse = { credential?: string };
 
@@ -47,6 +49,8 @@ const GoogleLoginForm: React.FC<GoogleLoginFormProps> = ({
   redirectPath = "/",
   onTotpChallenge,
 }) => {
+    const { strings, openSettings, consent } = useCookieConsent();
+    const thirdPartyAllowed = acceptsThirdParty();
     const [error, setError] = useState<string>("");
     const [scriptReady, setScriptReady] = useState<boolean>(false);
     const buttonContainerRef = useRef<HTMLDivElement>(null);
@@ -179,6 +183,11 @@ const GoogleLoginForm: React.FC<GoogleLoginFormProps> = ({
 
         const initGoogle = async () => {
             setScriptReady(false);
+            setError("");
+
+            if (!thirdPartyAllowed) {
+                return;
+            }
 
             const { googleClientId } = getRuntimeEnv();
             if (!googleClientId) {
@@ -229,7 +238,7 @@ const GoogleLoginForm: React.FC<GoogleLoginFormProps> = ({
         return () => {
             cancelled = true;
         };
-    }, [handleGoogleCredential, renderGoogleButton]);
+    }, [handleGoogleCredential, renderGoogleButton, thirdPartyAllowed, consent?.decidedAt]);
 
     useEffect(() => {
         if (!scriptReady) {
@@ -257,11 +266,20 @@ const GoogleLoginForm: React.FC<GoogleLoginFormProps> = ({
         <>
             {error && <p className="error-message">{error}</p>}
 
-            <div className="login-item">
-                <div ref={buttonContainerRef} className="google-login-wrapper" />
-            </div>
+            {!thirdPartyAllowed ? (
+                <p className="google-consent-hint">
+                    {strings.googleSignInDisabled}{" "}
+                    <button type="button" onClick={openSettings}>
+                        {strings.cookieSettings}
+                    </button>
+                </p>
+            ) : (
+                <div className="login-item">
+                    <div ref={buttonContainerRef} className="google-login-wrapper" />
+                </div>
+            )}
 
-            {(!scriptReady || isPending) && (
+            {thirdPartyAllowed && (!scriptReady || isPending) && (
                 <div className="login-item">
                     <span>Loading...</span>
                 </div>

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -9,6 +9,7 @@ import { FaTelegramPlane, FaSun, FaMoon } from "react-icons/fa";
 import { appVersion } from "../../version.ts";
 import { useTheme } from "../../contexts/useTheme";
 import type { TotpChallengeState } from "../../utils/auth/handleLoginResponse";
+import GdprFooterLinks from "../gdpr/GdprFooterLinks";
 
 const LoginPage: React.FC = () => {
     const [showTelegramForm, setShowTelegramForm] = useState(false);
@@ -84,6 +85,7 @@ const LoginPage: React.FC = () => {
                         </p>
                     ) : null}
                     <p>© {new Date().getFullYear()} DataGate Monitor v.{appVersion}</p>
+                    <GdprFooterLinks />
                     <button
                         type="button"
                         className="login-theme-toggle"

--- a/src/components/auth/RegisterPage.tsx
+++ b/src/components/auth/RegisterPage.tsx
@@ -4,6 +4,8 @@ import { postApiAuthRegister } from "../../api/orval/auth/auth";
 import type { RegisterUserRequest } from "../../api/orvalModelShim";
 import { FaUserPlus } from "react-icons/fa";
 import { PasswordInput } from "./PasswordInput";
+import GdprFooterLinks from "../gdpr/GdprFooterLinks";
+import { useCookieConsent } from "../../contexts/CookieConsentContext";
 import "../../css/Login.css";
 import axios from "axios";
 import { axiosResponseDataMessage, errorMessage } from "../../utils/errorMessage";
@@ -14,11 +16,13 @@ interface RegisterPageProps {
 
 const RegisterPage: React.FC<RegisterPageProps> = ({ loginPath = "/login" }) => {
   const navigate = useNavigate();
+  const { strings } = useCookieConsent();
   const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -27,6 +31,7 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ loginPath = "/login" }) => 
     password.trim().length > 0 &&
     confirmPassword.trim().length > 0 &&
     password === confirmPassword &&
+    privacyAccepted &&
     !loading;
 
   const handleRegister = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -35,6 +40,11 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ loginPath = "/login" }) => 
 
     if (password !== confirmPassword) {
       setError("Passwords do not match.");
+      return;
+    }
+
+    if (!privacyAccepted) {
+      setError(strings.registerPrivacyRequired);
       return;
     }
 
@@ -172,6 +182,18 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ loginPath = "/login" }) => 
               />
             </div>
 
+            <label className="register-privacy-row">
+              <input
+                type="checkbox"
+                checked={privacyAccepted}
+                onChange={(event) => setPrivacyAccepted(event.target.checked)}
+              />
+              <span>
+                {strings.registerPrivacyLabel}{" "}
+                <Link to="/privacy">{strings.privacyPolicy}</Link>.
+              </span>
+            </label>
+
             <div className="login-item">
               <button
                 className="btn primary btn-fullwidth"
@@ -189,6 +211,7 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ loginPath = "/login" }) => 
           <p>
             Already have an account? <Link to={loginPath}>Sign in</Link>
           </p>
+          <GdprFooterLinks />
         </div>
       </div>
     </div>

--- a/src/components/gdpr/CookieConsentBanner.tsx
+++ b/src/components/gdpr/CookieConsentBanner.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useCookieConsent } from "../../contexts/CookieConsentContext";
+import "../../css/CookieConsent.css";
+
+export const CookieConsentBanner: React.FC = () => {
+  const { hasDecision, strings, acceptAll, rejectNonEssential, openSettings } = useCookieConsent();
+  const [visible, setVisible] = useState(() => !hasDecision);
+
+  useEffect(() => {
+    setVisible(!hasDecision);
+  }, [hasDecision]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="cookie-consent-banner" role="dialog" aria-labelledby="cookie-consent-title">
+      <div className="cookie-consent-banner__content">
+        <h2 id="cookie-consent-title" className="cookie-consent-banner__title">
+          {strings.bannerTitle}
+        </h2>
+        <p className="cookie-consent-banner__text">{strings.bannerText}</p>
+        <p className="cookie-consent-banner__links">
+          <Link to="/privacy" className="cookie-consent-link">
+            {strings.privacyPolicy}
+          </Link>
+        </p>
+      </div>
+      <div className="cookie-consent-banner__actions">
+        <button type="button" className="btn secondary cookie-consent-btn" onClick={rejectNonEssential}>
+          {strings.rejectNonEssential}
+        </button>
+        <button type="button" className="btn secondary cookie-consent-btn" onClick={openSettings}>
+          {strings.customize}
+        </button>
+        <button type="button" className="btn primary cookie-consent-btn" onClick={acceptAll}>
+          {strings.acceptAll}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsentBanner;

--- a/src/components/gdpr/CookieSettingsPanel.tsx
+++ b/src/components/gdpr/CookieSettingsPanel.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useCookieConsent } from "../../contexts/CookieConsentContext";
+import "../../css/CookieConsent.css";
+
+export const CookieSettingsPanel: React.FC = () => {
+  const { consent, settingsOpen, strings, savePreferences, closeSettings } = useCookieConsent();
+  const [functional, setFunctional] = useState(consent?.functional ?? false);
+  const [thirdParty, setThirdParty] = useState(consent?.thirdParty ?? false);
+
+  useEffect(() => {
+    if (!settingsOpen) return;
+    setFunctional(consent?.functional ?? false);
+    setThirdParty(consent?.thirdParty ?? false);
+  }, [consent?.functional, consent?.thirdParty, settingsOpen]);
+
+  if (!settingsOpen) return null;
+
+  return (
+    <div className="cookie-settings-overlay" role="presentation" onClick={closeSettings}>
+      <div
+        className="cookie-settings-panel"
+        role="dialog"
+        aria-labelledby="cookie-settings-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 id="cookie-settings-title" className="cookie-settings-panel__title">
+          {strings.settingsTitle}
+        </h2>
+        <p className="cookie-settings-panel__description">{strings.settingsDescription}</p>
+
+        <div className="cookie-settings-category">
+          <div className="cookie-settings-category__header">
+            <strong>{strings.categoryEssential}</strong>
+            <span className="cookie-settings-badge">{strings.alwaysOn}</span>
+          </div>
+          <p>{strings.categoryEssentialDesc}</p>
+        </div>
+
+        <label className="cookie-settings-category cookie-settings-toggle">
+          <div className="cookie-settings-category__header">
+            <strong>{strings.categoryFunctional}</strong>
+            <input
+              type="checkbox"
+              checked={functional}
+              onChange={(event) => setFunctional(event.target.checked)}
+            />
+          </div>
+          <p>{strings.categoryFunctionalDesc}</p>
+        </label>
+
+        <label className="cookie-settings-category cookie-settings-toggle">
+          <div className="cookie-settings-category__header">
+            <strong>{strings.categoryThirdParty}</strong>
+            <input
+              type="checkbox"
+              checked={thirdParty}
+              onChange={(event) => setThirdParty(event.target.checked)}
+            />
+          </div>
+          <p>{strings.categoryThirdPartyDesc}</p>
+        </label>
+
+        <p className="cookie-settings-panel__links">
+          <Link to="/privacy" className="cookie-consent-link" onClick={closeSettings}>
+            {strings.privacyPolicy}
+          </Link>
+        </p>
+
+        <div className="cookie-settings-panel__actions">
+          <button type="button" className="btn secondary" onClick={closeSettings}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn primary"
+            onClick={() => savePreferences({ functional, thirdParty })}
+          >
+            {strings.savePreferences}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieSettingsPanel;

--- a/src/components/gdpr/GdprFooterLinks.tsx
+++ b/src/components/gdpr/GdprFooterLinks.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { useCookieConsent } from "../../contexts/CookieConsentContext";
+import "../../css/CookieConsent.css";
+
+type GdprFooterLinksProps = {
+  className?: string;
+};
+
+const GdprFooterLinks: React.FC<GdprFooterLinksProps> = ({ className = "" }) => {
+  const { strings, openSettings } = useCookieConsent();
+
+  return (
+    <nav className={`gdpr-footer-links ${className}`.trim()} aria-label="Legal">
+      <Link to="/privacy">{strings.privacyPolicy}</Link>
+      <button type="button" onClick={openSettings}>
+        {strings.cookieSettings}
+      </button>
+    </nav>
+  );
+};
+
+export default GdprFooterLinks;

--- a/src/components/settings/GeoPointsMap.tsx
+++ b/src/components/settings/GeoPointsMap.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { MapContainer, TileLayer, Marker, Popup, useMap } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
-import Cookies from "js-cookie";
+import { getPreferenceCookie, setPreferenceCookie } from "../../utils/gdpr/cookieConsent";
 import "leaflet-defaulticon-compatibility";
 import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
 import { toast } from "react-toastify";
@@ -239,13 +239,13 @@ export const GeoPointsMap: React.FC<GeoPointsMapProps> = ({
                                                           }) => {
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const [selectedLayer, setSelectedLayer] = useState<keyof typeof tileLayers>(
-        (Cookies.get("selectedMapLayer") as keyof typeof tileLayers) || "Carto Dark"
+        (getPreferenceCookie("selectedMapLayer") as keyof typeof tileLayers) || "Carto Dark"
     );
     const [pointStyle, setPointStyle] = useState<"by_traffic" | "single">(
-        (Cookies.get("geoPointStyle") as "by_traffic" | "single") || "by_traffic"
+        (getPreferenceCookie("geoPointStyle") as "by_traffic" | "single") || "by_traffic"
     );
     const [pointColor, setPointColor] = useState<PointColorKey>(
-        (Cookies.get("geoPointColor") as PointColorKey) || "blue"
+        (getPreferenceCookie("geoPointColor") as PointColorKey) || "blue"
     );
     const [points, setPoints] = useState<GeoPointAggDto[]>([]);
     const [hideZeroTraffic, setHideZeroTraffic] = useState(false);
@@ -278,13 +278,13 @@ export const GeoPointsMap: React.FC<GeoPointsMapProps> = ({
     };
 
     useEffect(() => {
-        Cookies.set("selectedMapLayer", selectedLayer, { expires: 365 });
+        setPreferenceCookie("selectedMapLayer", selectedLayer);
     }, [selectedLayer]);
     useEffect(() => {
-        Cookies.set("geoPointStyle", pointStyle, { expires: 365 });
+        setPreferenceCookie("geoPointStyle", pointStyle);
     }, [pointStyle]);
     useEffect(() => {
-        Cookies.set("geoPointColor", pointColor, { expires: 365 });
+        setPreferenceCookie("geoPointColor", pointColor);
     }, [pointColor]);
 
     useEffect(() => {

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -1,6 +1,7 @@
 // src/components/ui/Footer.tsx
 import React from "react";
 import { appVersion } from "../../version";
+import GdprFooterLinks from "../gdpr/GdprFooterLinks";
 import "../../css/Footer.css";
 
 const Footer: React.FC = () => {
@@ -9,6 +10,7 @@ const Footer: React.FC = () => {
             <p className="footer-line">
                 © {new Date().getFullYear()} DataGate Monitor v.{appVersion}
             </p>
+            <GdprFooterLinks />
         </footer>
     );
 };

--- a/src/contexts/CookieConsentContext.tsx
+++ b/src/contexts/CookieConsentContext.tsx
@@ -1,0 +1,72 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useLocation } from "react-router-dom";
+import {
+  getCookieConsent,
+  setCookieConsent,
+  type CookieConsentInput,
+  type CookieConsentState,
+} from "../utils/gdpr/cookieConsent";
+import { getGdprStrings, resolveGdprLanguageFromPath } from "../utils/gdpr/i18n";
+
+type CookieConsentContextValue = {
+  consent: CookieConsentState | null;
+  hasDecision: boolean;
+  settingsOpen: boolean;
+  strings: ReturnType<typeof getGdprStrings>;
+  acceptAll: () => void;
+  rejectNonEssential: () => void;
+  savePreferences: (input: CookieConsentInput) => void;
+  openSettings: () => void;
+  closeSettings: () => void;
+};
+
+const CookieConsentContext = createContext<CookieConsentContextValue | null>(null);
+
+export function CookieConsentProvider({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const [consent, setConsent] = useState<CookieConsentState | null>(() => getCookieConsent());
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const lang = resolveGdprLanguageFromPath(location.pathname);
+  const strings = useMemo(() => getGdprStrings(lang), [lang]);
+
+  const applyConsent = useCallback((input: CookieConsentInput) => {
+    const next = setCookieConsent(input);
+    setConsent(next);
+    setSettingsOpen(false);
+  }, []);
+
+  const value = useMemo<CookieConsentContextValue>(
+    () => ({
+      consent,
+      hasDecision: consent !== null,
+      settingsOpen,
+      strings,
+      acceptAll: () => applyConsent({ functional: true, thirdParty: true }),
+      rejectNonEssential: () => applyConsent({ functional: false, thirdParty: false }),
+      savePreferences: applyConsent,
+      openSettings: () => setSettingsOpen(true),
+      closeSettings: () => setSettingsOpen(false),
+    }),
+    [applyConsent, consent, settingsOpen, strings],
+  );
+
+  return (
+    <CookieConsentContext.Provider value={value}>{children}</CookieConsentContext.Provider>
+  );
+}
+
+export function useCookieConsent(): CookieConsentContextValue {
+  const ctx = useContext(CookieConsentContext);
+  if (!ctx) {
+    throw new Error("useCookieConsent must be used within CookieConsentProvider");
+  }
+  return ctx;
+}

--- a/src/css/CookieConsent.css
+++ b/src/css/CookieConsent.css
@@ -1,0 +1,182 @@
+.cookie-consent-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 12000;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  background: var(--bg-elevated, #161b22);
+  border-top: 1px solid var(--border-color, #30363d);
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.cookie-consent-banner__title {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  color: var(--text-primary, #f0f6fc);
+}
+
+.cookie-consent-banner__text,
+.cookie-consent-banner__links {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary, #c9d1d9);
+  line-height: 1.45;
+}
+
+.cookie-consent-banner__content {
+  flex: 1 1 320px;
+  max-width: 760px;
+}
+
+.cookie-consent-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.cookie-consent-btn {
+  white-space: nowrap;
+}
+
+.cookie-consent-link {
+  color: var(--accent-color, #58a6ff);
+  text-decoration: underline;
+}
+
+.cookie-settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 12001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(1, 4, 9, 0.72);
+}
+
+.cookie-settings-panel {
+  width: min(560px, 100%);
+  max-height: min(90vh, 720px);
+  overflow: auto;
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color, #30363d);
+  background: var(--bg-elevated, #161b22);
+  color: var(--text-primary, #f0f6fc);
+}
+
+.cookie-settings-panel__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.cookie-settings-panel__description,
+.cookie-settings-category p,
+.cookie-settings-panel__links {
+  margin: 0 0 0.75rem;
+  color: var(--text-secondary, #c9d1d9);
+  line-height: 1.45;
+  font-size: 0.92rem;
+}
+
+.cookie-settings-category {
+  display: block;
+  margin-bottom: 0.85rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 8px;
+}
+
+.cookie-settings-category__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.cookie-settings-badge {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(88, 166, 255, 0.15);
+  color: var(--accent-color, #58a6ff);
+}
+
+.cookie-settings-toggle input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cookie-settings-panel__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.gdpr-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  justify-content: center;
+  margin-top: 0.35rem;
+}
+
+.gdpr-footer-links a,
+.gdpr-footer-links button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent-color, #58a6ff);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.register-privacy-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0.75rem 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--text-secondary, #c9d1d9);
+}
+
+.register-privacy-row input {
+  margin-top: 0.2rem;
+}
+
+.google-consent-hint {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted, #8b949e);
+}
+
+.google-consent-hint button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent-color, #58a6ff);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .cookie-consent-banner__actions {
+    width: 100%;
+  }
+
+  .cookie-consent-btn {
+    flex: 1 1 auto;
+  }
+}

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import { FaEnvelope } from "react-icons/fa";
+import { resolveGdprLanguageFromPath, getGdprStrings } from "../utils/gdpr/i18n";
+import "../css/InfoPages.css";
+
+const CONTACT_EMAIL = "imkolganov@gmail.com";
+
+const PrivacyPolicy: React.FC = () => {
+  const location = useLocation();
+  const lang = resolveGdprLanguageFromPath(location.pathname);
+  const gdpr = getGdprStrings(lang);
+  const backToXray = location.pathname.startsWith("/xray") || document.referrer.includes("/xray");
+
+  return (
+    <div className="content-wrapper wide-table info-page privacy-page">
+      <h2>Privacy Policy</h2>
+      <hr className="info-divider" />
+      {gdpr.privacyIntroNote ? (
+        <p className="info-note">{gdpr.privacyIntroNote}</p>
+      ) : null}
+      <p>
+        <strong>Last updated:</strong> July 1, 2026
+      </p>
+      <p>
+        This Privacy Policy explains how <strong>DataGate Monitor</strong> and the public{" "}
+        <strong>XRay access portal</strong> (including pages under <code>/xray</code>) process personal
+        data when you use <code>dash.datagateapp.com</code> and related services operated by Ivan Kolganov
+        (“we”, “us”).
+      </p>
+
+      <section className="info-section">
+        <p>
+          <strong>1. Data we process</strong>
+        </p>
+        <ul>
+          <li>Account data: login, display name, email address, password hash, and authentication tokens.</li>
+          <li>
+            Third-party sign-in data: when you use Google Sign-In, we receive profile identifiers and email
+            from Google to authenticate you.
+          </li>
+          <li>
+            VPN / XRay service data: server assignments, generated access links, connection metadata needed
+            to provide the service.
+          </li>
+          <li>
+            Technical data: IP address, browser type, timestamps, and security logs required to operate and
+            protect the platform.
+          </li>
+          <li>
+            Optional UI preferences stored in your browser (for example map layer selection) when you consent
+            to preference storage.
+          </li>
+        </ul>
+      </section>
+
+      <section className="info-section">
+        <p>
+          <strong>2. Purposes and legal bases (GDPR)</strong>
+        </p>
+        <ul>
+          <li>
+            <strong>Contract / service delivery</strong> — creating and managing your account, issuing XRay
+            access, and operating the monitoring dashboard.
+          </li>
+          <li>
+            <strong>Legitimate interests</strong> — security monitoring, fraud prevention, and service
+            reliability, balanced against your rights.
+          </li>
+          <li>
+            <strong>Consent</strong> — optional browser storage for UI preferences and loading Google
+            Identity Services for “Sign in with Google”.
+          </li>
+          <li>
+            <strong>Legal obligation</strong> — where applicable law requires retention or disclosure.
+          </li>
+        </ul>
+      </section>
+
+      <section className="info-section">
+        <p>
+          <strong>3. Cookies and local storage</strong>
+        </p>
+        <p>We use the following categories:</p>
+        <ul>
+          <li>
+            <strong>Essential</strong> — authentication tokens, session security, and core application state.
+            These are required and do not require consent.
+          </li>
+          <li>
+            <strong>Preferences</strong> — optional settings such as map display choices. Stored only after
+            you accept preference storage in the cookie banner.
+          </li>
+          <li>
+            <strong>Third-party sign-in</strong> — Google Identity Services script loaded only if you enable
+            this category and choose Google Sign-In.
+          </li>
+        </ul>
+        <p>
+          You can change your choices at any time via <strong>Cookie settings</strong> in the site footer or
+          the consent banner.
+        </p>
+      </section>
+
+      <section className="info-section">
+        <p>
+          <strong>4. Recipients and international transfers</strong>
+        </p>
+        <p>
+          We use infrastructure and subprocessors needed to host the service. If you enable Google Sign-In,
+          Google LLC processes data according to{" "}
+          <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">
+            Google&apos;s Privacy Policy
+          </a>
+          . Where data is transferred outside the EEA, we rely on appropriate safeguards such as Standard
+          Contractual Clauses where required.
+        </p>
+      </section>
+
+      <section className="info-section">
+        <p>
+          <strong>5. Retention</strong>
+        </p>
+        <p>
+          Account and service data are kept while your account is active and as needed for security, billing,
+          or legal compliance. Authentication logs and operational records are retained for a limited period
+          aligned with security needs.
+        </p>
+      </section>
+
+      <section className="info-section">
+        <p>
+          <strong>6. Your rights</strong>
+        </p>
+        <p>
+          If you are in the EEA, UK, or Switzerland, you may have the right to access, rectify, erase,
+          restrict, or object to processing, and to data portability. Where processing is based on consent,
+          you may withdraw consent at any time without affecting prior lawful processing. You may lodge a
+          complaint with your local supervisory authority.
+        </p>
+      </section>
+
+      <section className="info-section">
+        <p>
+          <strong>7. Contact</strong>
+        </p>
+        <p className="info-list-item">
+          <FaEnvelope className="info-icon" aria-hidden />
+          Data protection contact:{" "}
+          <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+        </p>
+      </section>
+
+      <p className="info-note">
+        {backToXray ? (
+          <>
+            Return to <Link to="/xray/login">XRay portal sign-in</Link> or{" "}
+            <Link to="/login">admin sign-in</Link>.
+          </>
+        ) : (
+          <>
+            Return to <Link to="/login">sign-in</Link> or <Link to="/xray/login">XRay portal</Link>.
+          </>
+        )}
+      </p>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/src/pages/xray/XrayLoginPage.tsx
+++ b/src/pages/xray/XrayLoginPage.tsx
@@ -16,6 +16,7 @@ import GoogleLoginForm from "../../components/auth/GoogleLoginForm";
 import { axiosResponseDataMessage, axiosResponseDetail, errorMessage } from "../../utils/errorMessage";
 import { getXrayLanguage, setXrayLanguage, XRAY_LANGUAGE_OPTIONS, XRAY_TRANSLATIONS } from "./i18n";
 import { appVersion } from "../../version";
+import GdprFooterLinks from "../../components/gdpr/GdprFooterLinks";
 import "../../css/XrayPortal.css";
 
 const XrayLoginPage: React.FC = () => {
@@ -201,6 +202,7 @@ const XrayLoginPage: React.FC = () => {
           <p className="xray-warning">{t.warningIos}</p>
         </div>
         <p className="xray-note xray-login-version">© {new Date().getFullYear()} DataGate Monitor v.{appVersion}</p>
+        <GdprFooterLinks />
       </div>
     </div>
   );

--- a/src/pages/xray/XrayPortalPage.tsx
+++ b/src/pages/xray/XrayPortalPage.tsx
@@ -18,6 +18,7 @@ import { providerExternalIdFromJwtClaims } from "../../utils/auth/providerExtern
 import { VpnServerType } from "../../constants/vpnServerType";
 import { getXrayLanguage, setXrayLanguage, XRAY_LANGUAGE_OPTIONS, XRAY_TRANSLATIONS } from "./i18n";
 import { appVersion } from "../../version";
+import GdprFooterLinks from "../../components/gdpr/GdprFooterLinks";
 import "../../css/XrayPortal.css";
 
 const EMAIL_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
@@ -284,6 +285,7 @@ const XrayPortalPage: React.FC = () => {
       </section>
 
       <p className="xray-note xray-login-version">© {new Date().getFullYear()} DataGate Monitor v.{appVersion}</p>
+      <GdprFooterLinks />
     </div>
   );
 };

--- a/src/pages/xray/XrayRegisterPage.tsx
+++ b/src/pages/xray/XrayRegisterPage.tsx
@@ -8,18 +8,22 @@ import { PasswordInput } from "../../components/auth/PasswordInput";
 import { ACCESS_TOKEN_KEY } from "../../utils/const";
 import { axiosResponseDataMessage, errorMessage } from "../../utils/errorMessage";
 import { getXrayLanguage, setXrayLanguage, XRAY_LANGUAGE_OPTIONS, XRAY_TRANSLATIONS } from "./i18n";
+import { getGdprStrings } from "../../utils/gdpr/i18n";
+import GdprFooterLinks from "../../components/gdpr/GdprFooterLinks";
 import "../../css/XrayPortal.css";
 
 const XrayRegisterPage: React.FC = () => {
   const navigate = useNavigate();
   const [lang, setLang] = useState(getXrayLanguage);
   const t = XRAY_TRANSLATIONS[lang].register;
+  const gdpr = getGdprStrings(lang);
 
   const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -33,6 +37,7 @@ const XrayRegisterPage: React.FC = () => {
     password.trim().length > 0 &&
     confirmPassword.trim().length > 0 &&
     password === confirmPassword &&
+    privacyAccepted &&
     !loading;
 
   const handleRegister = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -41,6 +46,11 @@ const XrayRegisterPage: React.FC = () => {
 
     if (password !== confirmPassword) {
       setError(t.passwordsDoNotMatch);
+      return;
+    }
+
+    if (!privacyAccepted) {
+      setError(gdpr.registerPrivacyRequired);
       return;
     }
 
@@ -174,6 +184,18 @@ const XrayRegisterPage: React.FC = () => {
               required
             />
 
+            <label className="register-privacy-row">
+              <input
+                type="checkbox"
+                checked={privacyAccepted}
+                onChange={(event) => setPrivacyAccepted(event.target.checked)}
+              />
+              <span>
+                {gdpr.registerPrivacyLabel}{" "}
+                <Link to="/privacy">{gdpr.privacyPolicy}</Link>.
+              </span>
+            </label>
+
             <button className="btn primary btn-fullwidth" type="submit" disabled={!canSubmit}>
               <FaUserPlus className="icon" /> {loading ? t.creatingAccount : t.createAccount}
             </button>
@@ -185,6 +207,7 @@ const XrayRegisterPage: React.FC = () => {
             </p>
           </div>
         </div>
+        <GdprFooterLinks />
       </div>
     </div>
   );

--- a/src/utils/gdpr/cookieConsent.test.ts
+++ b/src/utils/gdpr/cookieConsent.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  COOKIE_CONSENT_STORAGE_KEY,
+  COOKIE_CONSENT_VERSION,
+  acceptsFunctional,
+  acceptsThirdParty,
+  getCookieConsent,
+  hasConsentDecision,
+  setCookieConsent,
+} from "./cookieConsent";
+
+describe("cookieConsent", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts without a stored decision", () => {
+    expect(hasConsentDecision()).toBe(false);
+    expect(getCookieConsent()).toBeNull();
+    expect(acceptsFunctional()).toBe(false);
+    expect(acceptsThirdParty()).toBe(false);
+  });
+
+  it("persists accept-all preferences", () => {
+    const saved = setCookieConsent({ functional: true, thirdParty: true });
+    expect(saved.functional).toBe(true);
+    expect(saved.thirdParty).toBe(true);
+    expect(saved.version).toBe(COOKIE_CONSENT_VERSION);
+    expect(localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY)).toContain('"functional":true');
+    expect(acceptsFunctional()).toBe(true);
+    expect(acceptsThirdParty()).toBe(true);
+  });
+
+  it("persists reject-non-essential preferences", () => {
+    setCookieConsent({ functional: false, thirdParty: false });
+    expect(acceptsFunctional()).toBe(false);
+    expect(acceptsThirdParty()).toBe(false);
+  });
+});

--- a/src/utils/gdpr/cookieConsent.ts
+++ b/src/utils/gdpr/cookieConsent.ts
@@ -1,0 +1,117 @@
+import Cookies from "js-cookie";
+
+export const COOKIE_CONSENT_VERSION = 1;
+export const COOKIE_CONSENT_STORAGE_KEY = "datagate.cookieConsent";
+
+export const PREFERENCE_COOKIE_KEYS = [
+  "selectedMapLayer",
+  "selectedPointColor",
+  "selectedMapViewMode",
+  "selectedMapPerformanceMode",
+  "selectedGlobeTrafficLayer",
+  "geoPointStyle",
+  "geoPointColor",
+] as const;
+
+export interface CookieConsentState {
+  essential: true;
+  functional: boolean;
+  thirdParty: boolean;
+  decidedAt: string;
+  version: number;
+}
+
+export type CookieConsentInput = Pick<CookieConsentState, "functional" | "thirdParty">;
+
+function parseConsent(raw: string | null): CookieConsentState | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CookieConsentState>;
+    if (
+      parsed.version !== COOKIE_CONSENT_VERSION ||
+      typeof parsed.functional !== "boolean" ||
+      typeof parsed.thirdParty !== "boolean" ||
+      typeof parsed.decidedAt !== "string"
+    ) {
+      return null;
+    }
+    return {
+      essential: true,
+      functional: parsed.functional,
+      thirdParty: parsed.thirdParty,
+      decidedAt: parsed.decidedAt,
+      version: parsed.version,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getCookieConsent(): CookieConsentState | null {
+  try {
+    return parseConsent(localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function hasConsentDecision(): boolean {
+  return getCookieConsent() !== null;
+}
+
+export function acceptsFunctional(): boolean {
+  return getCookieConsent()?.functional === true;
+}
+
+export function acceptsThirdParty(): boolean {
+  return getCookieConsent()?.thirdParty === true;
+}
+
+export function clearPreferenceCookies(): void {
+  for (const key of PREFERENCE_COOKIE_KEYS) {
+    Cookies.remove(key);
+  }
+}
+
+export function setCookieConsent(input: CookieConsentInput): CookieConsentState {
+  const previous = getCookieConsent();
+  const next: CookieConsentState = {
+    essential: true,
+    functional: input.functional,
+    thirdParty: input.thirdParty,
+    decidedAt: new Date().toISOString(),
+    version: COOKIE_CONSENT_VERSION,
+  };
+
+  localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(next));
+
+  if (!next.functional && (previous?.functional || !previous)) {
+    clearPreferenceCookies();
+  }
+
+  if (!next.thirdParty) {
+    removeGoogleIdentityScript();
+  }
+
+  return next;
+}
+
+export function setPreferenceCookie(name: string, value: string): void {
+  if (!acceptsFunctional()) return;
+  Cookies.set(name, value, { expires: 365 });
+}
+
+export function getPreferenceCookie(name: string): string | undefined {
+  return Cookies.get(name);
+}
+
+const GOOGLE_SCRIPT_ID = "google-identity-script";
+
+export function removeGoogleIdentityScript(): void {
+  document.getElementById(GOOGLE_SCRIPT_ID)?.remove();
+  try {
+    delete (window as Window & { google?: unknown }).google;
+  } catch {
+    (window as Window & { google?: unknown }).google = undefined;
+  }
+}

--- a/src/utils/gdpr/i18n.ts
+++ b/src/utils/gdpr/i18n.ts
@@ -1,0 +1,179 @@
+import type { XrayLanguage } from "../../pages/xray/i18n";
+
+export type GdprLanguage = XrayLanguage;
+
+type GdprStrings = {
+  bannerTitle: string;
+  bannerText: string;
+  acceptAll: string;
+  rejectNonEssential: string;
+  customize: string;
+  settingsTitle: string;
+  settingsDescription: string;
+  categoryEssential: string;
+  categoryEssentialDesc: string;
+  categoryFunctional: string;
+  categoryFunctionalDesc: string;
+  categoryThirdParty: string;
+  categoryThirdPartyDesc: string;
+  alwaysOn: string;
+  savePreferences: string;
+  privacyPolicy: string;
+  cookieSettings: string;
+  googleSignInDisabled: string;
+  registerPrivacyLabel: string;
+  registerPrivacyRequired: string;
+  privacyIntroNote: string;
+};
+
+const EN: GdprStrings = {
+  bannerTitle: "We value your privacy",
+  bannerText:
+    "We use essential storage for sign-in and optional cookies for UI preferences and Google Sign-In. You can accept all, reject non-essential storage, or customize your choices. See our Privacy Policy for details.",
+  acceptAll: "Accept all",
+  rejectNonEssential: "Reject non-essential",
+  customize: "Customize",
+  settingsTitle: "Cookie preferences",
+  settingsDescription: "Choose which optional storage categories you allow. Essential storage is always enabled.",
+  categoryEssential: "Essential",
+  categoryEssentialDesc: "Authentication tokens, security, and core session state required to run the service.",
+  categoryFunctional: "Preferences",
+  categoryFunctionalDesc: "Map layer, theme-related UI choices, and similar settings stored in your browser.",
+  categoryThirdParty: "Third-party sign-in",
+  categoryThirdPartyDesc: "Loads Google Identity Services only when you use “Sign in with Google”.",
+  alwaysOn: "Always on",
+  savePreferences: "Save preferences",
+  privacyPolicy: "Privacy Policy",
+  cookieSettings: "Cookie settings",
+  googleSignInDisabled:
+    "Google Sign-In requires third-party cookies. Open cookie settings and enable “Third-party sign-in”.",
+  registerPrivacyLabel: "I have read and agree to the",
+  registerPrivacyRequired: "You must accept the Privacy Policy to create an account.",
+  privacyIntroNote: "",
+};
+
+const GDPR_TRANSLATIONS: Record<GdprLanguage, GdprStrings> = {
+  en: EN,
+  ru: {
+    ...EN,
+    bannerTitle: "Мы ценим вашу конфиденциальность",
+    bannerText:
+      "Мы используем обязательное хранилище для входа и необязательные cookie для настроек интерфейса и входа через Google. Вы можете принять все, отклонить необязательные или настроить выбор. Подробности — в Политике конфиденциальности.",
+    acceptAll: "Принять все",
+    rejectNonEssential: "Только обязательные",
+    customize: "Настроить",
+    settingsTitle: "Настройки cookie",
+    settingsDescription: "Выберите, какие необязательные категории хранения разрешить. Обязательные всегда включены.",
+    categoryEssential: "Обязательные",
+    categoryEssentialDesc: "Токены авторизации, безопасность и состояние сессии, необходимые для работы сервиса.",
+    categoryFunctional: "Настройки",
+    categoryFunctionalDesc: "Слой карты, параметры интерфейса и похожие настройки в браузере.",
+    categoryThirdParty: "Сторонний вход",
+    categoryThirdPartyDesc: "Загружает Google Identity Services только при входе через Google.",
+    alwaysOn: "Всегда включено",
+    savePreferences: "Сохранить",
+    privacyPolicy: "Политика конфиденциальности",
+    cookieSettings: "Настройки cookie",
+    googleSignInDisabled:
+      "Вход через Google требует сторонних cookie. Откройте настройки cookie и включите «Сторонний вход».",
+    registerPrivacyLabel: "Я прочитал(а) и согласен(на) с",
+    registerPrivacyRequired: "Для регистрации необходимо принять Политику конфиденциальности.",
+    privacyIntroNote: "Полный юридический текст политики конфиденциальности приведён на английском языке.",
+  },
+  de: {
+    ...EN,
+    bannerTitle: "Wir respektieren Ihre Privatsphäre",
+    bannerText:
+      "Wir verwenden notwendige Speicherung für die Anmeldung und optionale Cookies für UI-Einstellungen und Google-Anmeldung. Sie können alle akzeptieren, optionale ablehnen oder anpassen. Details in der Datenschutzerklärung.",
+    acceptAll: "Alle akzeptieren",
+    rejectNonEssential: "Nur notwendige",
+    customize: "Anpassen",
+    settingsTitle: "Cookie-Einstellungen",
+    settingsDescription: "Wählen Sie optionale Speicherkategorien. Notwendige sind immer aktiv.",
+    categoryEssential: "Notwendig",
+    categoryEssentialDesc: "Authentifizierung, Sicherheit und Sitzungszustand für den Betrieb des Dienstes.",
+    categoryFunctional: "Einstellungen",
+    categoryFunctionalDesc: "Kartenebene, UI-Optionen und ähnliche Browser-Einstellungen.",
+    categoryThirdParty: "Drittanbieter-Anmeldung",
+    categoryThirdPartyDesc: "Lädt Google Identity Services nur bei „Mit Google anmelden“.",
+    alwaysOn: "Immer aktiv",
+    savePreferences: "Speichern",
+    privacyPolicy: "Datenschutzerklärung",
+    cookieSettings: "Cookie-Einstellungen",
+    googleSignInDisabled:
+      "Google-Anmeldung erfordert Drittanbieter-Cookies. Öffnen Sie die Cookie-Einstellungen und aktivieren Sie „Drittanbieter-Anmeldung“.",
+    registerPrivacyLabel: "Ich habe die",
+    registerPrivacyRequired: "Sie müssen die Datenschutzerklärung akzeptieren, um ein Konto zu erstellen.",
+    privacyIntroNote: "Der vollständige rechtliche Text der Datenschutzerklärung ist auf Englisch.",
+  },
+  fr: {
+    ...EN,
+    bannerTitle: "Nous respectons votre vie privée",
+    bannerText:
+      "Nous utilisons un stockage essentiel pour la connexion et des cookies optionnels pour les préférences d’interface et la connexion Google. Acceptez tout, refusez l’optionnel ou personnalisez. Voir la Politique de confidentialité.",
+    acceptAll: "Tout accepter",
+    rejectNonEssential: "Essentiels uniquement",
+    customize: "Personnaliser",
+    settingsTitle: "Préférences cookies",
+    settingsDescription: "Choisissez les catégories optionnelles. Les essentielles restent toujours actives.",
+    categoryEssential: "Essentiels",
+    categoryEssentialDesc: "Jetons d’authentification, sécurité et état de session nécessaires au service.",
+    categoryFunctional: "Préférences",
+    categoryFunctionalDesc: "Couche de carte, choix d’interface et paramètres similaires dans le navigateur.",
+    categoryThirdParty: "Connexion tierce",
+    categoryThirdPartyDesc: "Charge Google Identity Services uniquement pour « Se connecter avec Google ».",
+    alwaysOn: "Toujours actif",
+    savePreferences: "Enregistrer",
+    privacyPolicy: "Politique de confidentialité",
+    cookieSettings: "Paramètres cookies",
+    googleSignInDisabled:
+      "La connexion Google nécessite des cookies tiers. Ouvrez les paramètres cookies et activez « Connexion tierce ».",
+    registerPrivacyLabel: "J’ai lu et j’accepte la",
+    registerPrivacyRequired: "Vous devez accepter la Politique de confidentialité pour créer un compte.",
+    privacyIntroNote: "Le texte juridique complet de la politique de confidentialité est en anglais.",
+  },
+  el: {
+    ...EN,
+    bannerTitle: "Σεβόμαστε το απόρρητό σας",
+    bannerText:
+      "Χρησιμοποιούμε απαραίτητη αποθήκευση για σύνδεση και προαιρετικά cookies για προτιμήσεις UI και σύνδεση Google. Μπορείτε να αποδεχτείτε όλα, να απορρίψετε τα προαιρετικά ή να προσαρμόσετε. Δείτε την Πολιτική Απορρήτου.",
+    acceptAll: "Αποδοχή όλων",
+    rejectNonEssential: "Μόνο απαραίτητα",
+    customize: "Προσαρμογή",
+    settingsTitle: "Προτιμήσεις cookies",
+    settingsDescription: "Επιλέξτε προαιρετικές κατηγορίες. Τα απαραίτητα είναι πάντα ενεργά.",
+    categoryEssential: "Απαραίτητα",
+    categoryEssentialDesc: "Διακριτικά αυθεντικοποίησης, ασφάλεια και κατάσταση συνεδρίας για τη λειτουργία.",
+    categoryFunctional: "Προτιμήσεις",
+    categoryFunctionalDesc: "Επίπεδο χάρτη, επιλογές UI και παρόμοια ρυθμίσεις στο πρόγραμμα περιήγησης.",
+    categoryThirdParty: "Σύνδεση τρίτων",
+    categoryThirdPartyDesc: "Φορτώνει Google Identity Services μόνο για «Σύνδεση με Google».",
+    alwaysOn: "Πάντα ενεργό",
+    savePreferences: "Αποθήκευση",
+    privacyPolicy: "Πολιτική Απορρήτου",
+    cookieSettings: "Ρυθμίσεις cookies",
+    googleSignInDisabled:
+      "Η σύνδεση Google απαιτεί cookies τρίτων. Ανοίξτε τις ρυθμίσεις cookies και ενεργοποιήστε «Σύνδεση τρίτων».",
+    registerPrivacyLabel: "Έχω διαβάσει και συμφωνώ με την",
+    registerPrivacyRequired: "Πρέπει να αποδεχτείτε την Πολιτική Απορρήτου για εγγραφή.",
+    privacyIntroNote: "Το πλήρες νομικό κείμενο της πολιτικής απορρήτου είναι στα αγγλικά.",
+  },
+};
+
+export function getGdprStrings(lang: GdprLanguage = "en"): GdprStrings {
+  return GDPR_TRANSLATIONS[lang] ?? EN;
+}
+
+export function resolveGdprLanguageFromPath(pathname: string): GdprLanguage {
+  const useXrayLanguage = pathname.startsWith("/xray") || pathname === "/privacy";
+  if (!useXrayLanguage) return "en";
+  try {
+    const saved = localStorage.getItem("xray.portal.language");
+    if (saved === "ru" || saved === "el" || saved === "en" || saved === "fr" || saved === "de") {
+      return saved;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "en";
+}


### PR DESCRIPTION
## Summary
- Add cookie consent banner with essential, preferences, and third-party categories for the admin app and public XRay portal (`/xray/*`).
- Add public `/privacy` page and footer links; registration requires accepting the privacy policy.
- Load Google Sign-In only after third-party consent; gate preference cookies behind user choice.

## Test plan
- [ ] Open site in a fresh browser/profile and confirm the cookie banner appears.
- [ ] Choose **Reject non-essential** and verify Google Sign-In stays disabled with a cookie-settings hint.
- [ ] Enable third-party cookies in settings and verify Google Sign-In loads on `/login` and `/xray/login`.
- [ ] Confirm `/privacy` is reachable without authentication.
- [ ] Try registration on `/register` and `/xray/register` without the privacy checkbox — submit should be blocked.
- [ ] Change map preferences after accepting functional cookies and confirm they persist across reload.